### PR TITLE
Use ZIP compression instead of lzma to avoid false virus detection

### DIFF
--- a/Additional/AdditionalPackaging.iss
+++ b/Additional/AdditionalPackaging.iss
@@ -24,7 +24,7 @@ DisableProgramGroupPage=yes
 PrivilegesRequired=lowest
 OutputDir=.
 OutputBaseFilename=additional_setup
-Compression=lzma
+Compression=zip
 SolidCompression=yes
 WizardStyle=modern
 


### PR DESCRIPTION
Chrome and Edge detect the Inno Setup generated exe as a virus or trojan, but this is purely because of the compression format.